### PR TITLE
Remove compiling of */**/*.md with scholmdCompiler

### DIFF
--- a/haskell/Site.hs
+++ b/haskell/Site.hs
@@ -27,7 +27,6 @@ main = hakyllWith config $ do
     match "resources/bibliography/*.csl" $ compile cslCompiler
     match "resources/bibliography/*.bib" $ compile biblioCompiler
     match "**/*.img.md" $ compile scholmdCompiler
-    match "*/**/*.md" $ compile scholmdCompiler
     match ("images/*" .||.  "google*.html" .||. "**/*.jpg" .||. "**/*.png") $ do
         route idRoute
         compile copyFileCompiler


### PR DESCRIPTION
Is this required? Doesn't appear to be.

I spent hours trying to figure out why the publication page was not getting a template, and this appears to be the cause of the problem.