### PR TITLE
Publication pages (fixes #13)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content/resources/bibliography"]
 	path = content/resources/bibliography
-	url = git@github.com:spl/bibliography.git
+	url = git@github.com:dragonfly-science/bibliography.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content/resources/bibliography"]
 	path = content/resources/bibliography
-	url = git@github.com:dragonfly-science/bibliography.git
+	url = git@github.com:spl/bibliography.git

--- a/content/pages/publications.md
+++ b/content/pages/publications.md
@@ -1,21 +1,9 @@
 ---
-Title: Publications
+title: Publications
 ---
 
 # Publications, reports, and presentations
 
 A complete list of Dragonfly publications and reports from 2007 to the present.
-Selected presentations are also included.
 
-## 2013 {.hide-cite-para}
-
-@richard_application_2013, @richard_demographic_2013
- @richard_risk2_2013 @richard_risk_2013 @thompson_dolphin_2013
-
-## 2006 {.hide-cite-para}
-
-@waugh2006svs
-
-## 2005 {.hide-cite-para}
-
-@law2005fps
+----

--- a/content/publications
+++ b/content/publications
@@ -1,0 +1,1 @@
+resources/bibliography/publications

--- a/content/publications
+++ b/content/publications
@@ -1,1 +1,0 @@
-resources/bibliography/publications

--- a/content/publications/abraham1997smw.md
+++ b/content/publications/abraham1997smw.md
@@ -1,0 +1,11 @@
+---
+keywords: [other-ocean]
+---
+Seiche currents were observed in Wellington Harbour, New Zealand, with an
+Acoustic Doppler Current Profiler (ADCP). A 600 kHz Broad-Band ADCP was deployed
+on the sea bed in Evans Bay in an upwards looking configuration for 20 days. The
+measured seiche periods were 159, 26, 17.3, and 8.3 min and there was evidence
+for seiching at periods of 15.8 and 14.7 min. These observations are in close
+agreement with the previous predictions of a finite-difference numerical model.
+The seiching occurred during periods of wind with speeds in excess of 10 m s^-1.
+The seiches were found to be barotropic.

--- a/content/publications/abraham2002csm.md
+++ b/content/publications/abraham2002csm.md
@@ -1,0 +1,16 @@
+---
+keywords: [stirring]
+---
+The horizontal stirring properties of the flow in a region of the East
+Australian Current are calculated. A surface velocity field derived from
+remotely sensed data, using the maximum cross correlation method, is integrated
+to derive the distribution of the finite-time Lyapunov exponents. For the
+region studied (between latitudes 36°S and 41°S and longitudes 150°E and 156°E)
+the mean Lyapunov exponent during 1997 is estimated to be
+λ<sub>∞</sub>=4×10<sup>-7</sup>s<sup>-1</sup>. This is in close agreement with
+the few other measurements of stirring rates in the surface ocean which are
+available. Recent theoretical results on the multifractal spectra of advected
+reactive tracers are applied to an analysis of a sea-surface temperature image
+of the study region. The spatial pattern seen in the image compares well with
+the pattern seen in an advected tracer with a first-order response to changes
+in surface forcing. The response timescale is estimated to be 20 days.

--- a/content/templates/publication-list.html
+++ b/content/templates/publication-list.html
@@ -1,0 +1,32 @@
+<div class="container menu-spacer">
+    <div class="content wide">
+      <p>
+      </p>
+    </div>
+</div>
+
+<div class="container">
+  <div class="sidebar">
+  </div>
+  <div class="content">
+    <div class="post-list">
+      blah_work
+      <div class="post-wrapper">
+      <div class="post">    
+          <div class="post-image">
+            <a href="blah_pageurl"><div class="post-porthole" style="background-image: url('blah_teaserImage')">
+            </div></a>
+          </div>
+          <div class="post-teaser">
+            <h4><a href="blah_pageurl">$title$</a></h4>
+            <p class="subheading">blah_published $if(author)$ . $author$ $endif$ </p>
+            $if(teaser)$ $teaser$ $endif$
+            <span><a href="blah_pageurl" class="read-more">Read more &#9656;</a></span>
+          </div>
+      </div>
+      </div>
+      blah_work
+    </div>
+  </div>
+</div>
+

--- a/content/templates/publication-list.html
+++ b/content/templates/publication-list.html
@@ -1,32 +1,7 @@
-<div class="container menu-spacer">
-    <div class="content wide">
-      <p>
-      </p>
-    </div>
-</div>
-
 <div class="container">
-  <div class="sidebar">
-  </div>
+  <div class="sidebar"></div>
   <div class="content">
-    <div class="post-list">
-      blah_work
-      <div class="post-wrapper">
-      <div class="post">    
-          <div class="post-image">
-            <a href="blah_pageurl"><div class="post-porthole" style="background-image: url('blah_teaserImage')">
-            </div></a>
-          </div>
-          <div class="post-teaser">
-            <h4><a href="blah_pageurl">$title$</a></h4>
-            <p class="subheading">blah_published $if(author)$ . $author$ $endif$ </p>
-            $if(teaser)$ $teaser$ $endif$
-            <span><a href="blah_pageurl" class="read-more">Read more &#9656;</a></span>
-          </div>
-      </div>
-      </div>
-      blah_work
-    </div>
+    $body$
+    $citations-by-year$
   </div>
 </div>
-

--- a/content/templates/publication.html
+++ b/content/templates/publication.html
@@ -1,0 +1,12 @@
+<div class="container post-detail">
+  <div class="wide post-info">
+    <h1>$title$</h1>
+  </div>
+  <div class="sidebar"></div>
+  <div class="content">
+    <h2>Citation</h2>
+    $citation$
+    <h2>Summary</h2>
+    $body$
+  </div>
+</div>

--- a/haskell/Site.hs
+++ b/haskell/Site.hs
@@ -10,6 +10,7 @@ import qualified WebSite.Work as Work
 import qualified WebSite.People as People
 import qualified WebSite.News as News
 import qualified WebSite.Resources as Resources
+import qualified WebSite.Publications as Publications
 
 config :: Configuration
 config = defaultConfiguration {
@@ -54,9 +55,12 @@ main = hakyllWith config $ do
 
     -- Work section
     News.rules
-   
+
     -- Resources section
     Resources.rules
+
+    -- Publications section
+    Publications.rules
 
     -- Contact page
     match "pages/contact.html" $ do

--- a/haskell/Site.hs
+++ b/haskell/Site.hs
@@ -25,8 +25,8 @@ main = hakyllWith config $ do
 
     match "templates/*" $ compile templateCompiler
 
-    match "resources/bibliography/*.csl" $ compile cslCompiler
-    match "resources/bibliography/*.bib" $ compile biblioCompiler
+    match "resources/bibliography/apa.csl" $ compile cslCompiler
+    match "resources/bibliography/mfish.bib" $ compile biblioCompiler
     match "**/*.img.md" $ compile scholmdCompiler
     match ("images/*" .||.  "google*.html" .||. "**/*.jpg" .||. "**/*.png") $ do
         route idRoute

--- a/haskell/WebSite/Bibliography.hs
+++ b/haskell/WebSite/Bibliography.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE RecordWildCards #-}
+module WebSite.Bibliography (
+  biblioCitations,
+  biblioCitationsByYear,
+  lookupRef,
+  refCitation,
+  refTitle,
+  refUrl,
+  refDoi,
+) where
+
+import Data.Char (isSpace)
+import Data.List (find, sortOn)
+import GHC.Exts (build)
+import System.Directory (doesFileExist)
+import System.FilePath (takeBaseName)
+import Text.CSL.Reference (Reference)
+import qualified Text.CSL.Reference as Ref
+import Text.CSL.Style (Formatted(unFormatted), Agent(..))
+import Text.Pandoc.Shared (stringify)
+
+import WebSite.Compilers (renderPandocBiblio)
+
+import Hakyll
+
+-- | Look up the BibTeX ID part of an identifier in a bibliography to see if
+-- there is a reference.
+lookupRef :: Identifier -> Item Biblio -> Maybe Reference
+lookupRef ident item | Biblio refs <- itemBody item = do
+    -- Get the BibTeX ID from the path.
+    let bibtexId = takeBaseName $ toFilePath ident
+    -- Find the matching reference ID in the bibliography.
+    find ((== bibtexId) . refId) refs
+
+filterBiblio :: (Reference -> Bool) -> Item Biblio -> Item Biblio
+filterBiblio c = fmap $ \(Biblio refs) -> Biblio (filter c refs)
+
+sortBiblioOn :: Ord a => (Reference -> a) -> Item Biblio -> Item Biblio
+sortBiblioOn f = fmap $ \(Biblio refs) -> Biblio (sortOn f refs)
+
+biblioByKeyword :: String -> Item Biblio -> Item Biblio
+biblioByKeyword kw = filterBiblio (elem kw . keywords . unformat . Ref.keyword)
+
+biblioCitations :: Item CSL -> Item Biblio -> Compiler String
+biblioCitations csl bib | Biblio refs <- itemBody bib = refCitations csl bib refs
+
+biblioCitationsByYear :: Item CSL -> Item Biblio -> Int -> Compiler String
+biblioCitationsByYear csl bib yr = biblioCitations csl $
+                                   sortBiblioOn refAuthorsSorted $
+                                   filterBiblio ((== show yr) . refYear) bib
+
+-- | Extract a comma-delimited (and arbitrarily spaced) list of words
+keywords :: String -> [String]
+keywords s = build (\c n -> keywords' c n s)
+  where
+    isSep c = isSpace c || c == ','
+    keywords' cons nil = go
+      where
+        go s = case dropWhile isSep s of
+            "" -> nil
+            s' -> let (w, s'') = break isSep s' in w `cons` go s''
+
+-- | Render references as HTML citations
+refCitations :: Item CSL -> Item Biblio -> [Reference] -> Compiler String
+refCitations csl bib = fmap concat . mapM (refCitation True csl bib)
+
+-- | Render a reference as an HTML citation
+refCitation :: Bool -> Item CSL -> Item Biblio -> Reference -> Compiler String
+refCitation includeLink csl bib ref = do
+    -- Check if the file exists before creating a link to it.
+    doInsert <-
+        if includeLink then
+            unsafeCompiler $ doesFileExist $ refPath ref "md"
+        else
+            return False
+    insertPageLink doInsert ref <$> asItem dummyInput (renderPandocBiblio csl bib)
+  where
+    rid = refId ref
+    -- The input is an empty body with dummy metadata to get Pandoc to generate
+    -- the HTML for the reference.
+    dummyInput = unlines ["---", "nocite: |", ' ':' ':'@':rid, "..."]
+
+-- | Replace zero width space separators with a link to the publication page.
+--
+-- The zero width space characters should be added in the CSL as prefix and suffix
+-- to the title.
+--
+-- This is a workaround for not being able to add links in the CSL or
+-- pandoc-citeproc. See https://github.com/jgm/pandoc-citeproc/issues/52 for an
+-- issue that could avoid the need for this hack.
+insertPageLink :: Bool -> Reference -> String -> String
+insertPageLink includeLink ref refStr
+  | True <- includeLink,
+    (beg, s1) <- span isNotSep refStr, _:s2 <- s1,
+    (mid, s3) <- span isNotSep s2, _:end <- s3 = concat
+      [beg, "<a href=\"/", refPath ref "html", "\">", mid, "</a>", end]
+  | otherwise =
+      -- Remove the separators since they are not being used.
+      filter isNotSep refStr
+  where
+    isNotSep = (/= '\8203')
+
+-- | Render the unformatted title of a reference
+refTitle :: Reference -> Compiler String
+refTitle = return . unformat . Ref.title
+
+-- | Render the URL of a reference
+refUrl :: Reference -> Compiler String
+refUrl = return . Ref.unLiteral . Ref.url
+
+-- | Render the DOI of a reference
+refDoi :: Reference -> Compiler String
+refDoi = return . Ref.unLiteral . Ref.doi
+
+-- | BibTeX identifier of a reference
+refId :: Reference -> String
+refId = Ref.unLiteral . Ref.refId
+
+-- | File path of a reference summary page
+refPath :: Reference -> String -> FilePath
+refPath ref ext = "publications/" ++ refId ref ++ '.':ext
+
+-- | Issue year of a reference.
+--
+-- Note that the Reference type has a number of date fields. This assumes the
+-- desired year is always in the 'issued' field and that there is only one entry
+-- in its list.
+refYear :: Reference -> String
+refYear ref
+  | [Ref.RefDate {Ref.year = Ref.Literal yr}] <- Ref.issued ref = yr
+  | otherwise = "unknown year"
+
+-- | Sortable text for ordering a bibliography by authors
+refAuthorsSorted :: Reference -> [[String]]
+refAuthorsSorted = map agentSortOrder . Ref.author
+
+-- | Sortable text for ordering authors
+--
+-- FIXME! This doesn't properly handle all the naming structures produced by
+-- Pandoc.
+agentSortOrder :: Agent -> [String]
+agentSortOrder Agent{..} = unformat familyName : map unformat givenName
+
+unformat :: Formatted -> String
+unformat = stringify . unFormatted
+
+asItem :: a -> (Item a -> Compiler (Item b)) -> Compiler b
+asItem x f = makeItem x >>= f >>= return . itemBody

--- a/haskell/WebSite/Collection.hs
+++ b/haskell/WebSite/Collection.hs
@@ -63,7 +63,7 @@ makeRules cc = do
             imageMeta <- loadAll ("**/*.img.md")
             pages <- getList cc 1000
             bubbles <- getBubbles cc (Just ident)
-            let ctx = ref <> base <> actualbodyField "actualbody" <> pages <> bubbles
+            let ctx = base <> ref <> actualbodyField "actualbody" <> pages <> bubbles
             scholmdCompiler 
                 >>= loadAndApplyTemplate (pageTemplate cc) ctx
                 >>= loadAndApplyTemplate "templates/default.html" ctx

--- a/haskell/WebSite/Collection.hs
+++ b/haskell/WebSite/Collection.hs
@@ -41,9 +41,10 @@ makeRules cc = do
         route $ constRoute (indexTemplate cc)
         compile $ do 
             base <- baseContext (baseName cc)
+            bib <- biblioContext
             pages <- getList cc 1000
             bubbles <- getBubbles cc Nothing
-            let  ctx = base <> pages <> bubbles
+            let  ctx = base <> bib <> pages <> bubbles
             scholmdCompiler 
                 >>= loadAndApplyTemplate (collectionTemplate cc) ctx
                 >>= loadAndApplyTemplate "templates/default.html" ctx

--- a/haskell/WebSite/Collection.hs
+++ b/haskell/WebSite/Collection.hs
@@ -13,6 +13,8 @@ import Data.Monoid ((<>))
 import Data.Maybe (fromMaybe, maybeToList)
 import System.FilePath
 
+import Text.Pandoc
+
 import Hakyll
 
 import WebSite.Context
@@ -57,10 +59,11 @@ makeRules cc = do
         compile $ do 
             ident <- getUnderlying
             base <- baseContext (baseName cc)
+            ref <- refContext
             imageMeta <- loadAll ("**/*.img.md")
             pages <- getList cc 1000
             bubbles <- getBubbles cc (Just ident)
-            let ctx = base <> actualbodyField "actualbody" <> pages <> bubbles
+            let ctx = ref <> base <> actualbodyField "actualbody" <> pages <> bubbles
             scholmdCompiler 
                 >>= loadAndApplyTemplate (pageTemplate cc) ctx
                 >>= loadAndApplyTemplate "templates/default.html" ctx
@@ -137,5 +140,3 @@ portholeImage = field "portholeImage" getImagePath
             base = dropExtension path
             ident = fromFilePath $ base </> "porthole.png"
         fmap (maybe "" toUrl) (getRoute ident)
-
-

--- a/haskell/WebSite/Context.hs
+++ b/haskell/WebSite/Context.hs
@@ -2,11 +2,21 @@
 module WebSite.Context (
   baseContext,
   actualbodyField,
-  pageUrlField
+  pageUrlField,
+  refContext
 ) where
 
+import Data.List (find)
 import Data.Monoid ((<>))
 import System.FilePath (takeBaseName, replaceExtension)
+
+import Text.CSL.Reference (Reference)
+import Text.CSL.Style (Formatted(unFormatted))
+import qualified Text.CSL.Reference as Ref
+
+import Text.Pandoc.Shared (stringify)
+
+import WebSite.Compilers (renderPandocBiblio)
 
 import Hakyll
 
@@ -37,3 +47,41 @@ pageUrlField key = field key $ \item -> do
     let pseudoPath = toFilePath (itemIdentifier item)
         path = "/" ++ pseudoPath
     return (replaceExtension path ".html")
+
+-- Provide the reference data as context if the item is a BibTeX reference.
+refContext :: Compiler (Context String)
+refContext = do
+    csl <- load "resources/bibliography/apa.csl"
+    bib <- load "resources/bibliography/mfish.bib"
+    return $ mkField "title" refTitle bib <>
+             mkField "citation" (refCitation csl bib) bib
+  where
+    mkField k fromRef bib = field k $
+        maybe (fail "") fromRef . flip lookupRef bib . itemIdentifier
+
+-- | Look up the BibTeX ID part of an identifier in a bibliography to see if
+-- there is a reference.
+lookupRef :: Identifier -> Item Biblio -> Maybe Reference
+lookupRef ident Item{itemBody = Biblio refs} = do
+    -- Get the BibTeX ID from the path.
+    let bibtexId = takeBaseName $ toFilePath ident
+    -- Find the matching reference ID in the bibliography.
+    find ((== bibtexId) . refId) refs
+
+-- | Render the unformatted title of a reference
+refTitle :: Reference -> Compiler String
+refTitle = return . stringify . unFormatted . Ref.title
+
+-- | Render the citation HTML for a reference
+refCitation :: Item CSL -> Item Biblio -> Reference -> Compiler String
+refCitation csl bib ref = asItem dummyInput $ renderPandocBiblio csl bib
+  where
+    -- The input is an empty body with dummy metadata to get Pandoc to generate
+    -- the HTML for a reference list with only the one citation.
+    dummyInput = unlines ["---", "nocite: |", ' ':' ':'@':refId ref, "..."]
+
+refId :: Reference -> String
+refId = Ref.unLiteral . Ref.refId
+
+asItem :: a -> (Item a -> Compiler (Item b)) -> Compiler b
+asItem x f = makeItem x >>= f >>= return . itemBody

--- a/haskell/WebSite/Publications.hs
+++ b/haskell/WebSite/Publications.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module WebSite.Publications (
+    rules, list
+) where
+
+import WebSite.Collection
+
+config = CollectionConfig
+       { baseName            = "publications"
+       , indexTemplate       = "publications/index.html"
+       , indexPattern        = "pages/publications.md"
+       , collectionPattern   = "publications/*.md"
+       , collectionTemplate  = "templates/publication-list.html"
+       , pageTemplate        = "templates/publication.html"
+       }
+
+rules :: Rules()
+rules = makeRules config
+
+list = getList config


### PR DESCRIPTION
This is a preview of publication pages. I would not merge this as-is. See the comments below.

Features:

* Renders an HTML page for each Markdown in `content/resources/bibliography/publications/*.md`
* The page includes the citation according to the CSL plus the abstract as given by the body of the Markdown.
* See the sample pages at `http://localhost:8000/publications/abraham1997smw.html` and `http://localhost:8000/publications/abraham2002csm.html` .

Comments:

* The `publication-list.html` is a dummy file for use with the `WebSite.Collection` approach. This can be changed later.
* To demonstrate some publication pages, I changed the bibliography submodule to point to spl/bibliography@d286dfce327846ee6fc5eb61ac4cf6a684d9ea8e, where I included some publication Markdown abstracts. These are the files that would be added to the bibliography repository.
* I added a symlink for the publications directory because it makes the URLs look nicer. Ideally, this effect should probably be achieved with routes in Hakyll, but that might involve changing `WebSite.Collection`, which I didn't want to do at the moment.
* I do some fancy gymnastics (technical term) in `WebSite.Context` in order to (1) determine if an identifier is a publication page and (2) get the citation rendered in HTML (round-tripping some generated dummy Markdown text through Pandoc).
* Currently, the reference title and full citation are collected from the BibTeX file. More can be added later.