### PR TITLE
Use citation templates for citations in .md pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content/resources/bibliography"]
 	path = content/resources/bibliography
-	url = git@github.com:dragonfly-science/bibliography.git
+	url = git@github.com:spl/bibliography.git

--- a/content/news/2011-04-13-estimated-sea-lion-bycatch-2008-09.md
+++ b/content/news/2011-04-13-estimated-sea-lion-bycatch-2008-09.md
@@ -1,5 +1,7 @@
 ---
 title: Estimated sea lion bycatch in 2008–09
+nocite: |
+  @thompson_sealions_95-09
 ---
 
 Dragonfly Science estimated that around 78 sea lions were caught in
@@ -60,9 +62,3 @@ International Union for Conservation of Nature (IUCN) Red List. This
 means that it is believed that, if causal factors continue to operate,
 the species is likely to move into the Endangered category in the near
 future.
-
-###Publications
-[References key=thompson_sealions_95-09]
-
-
-

--- a/content/templates/append-publications.html
+++ b/content/templates/append-publications.html
@@ -1,0 +1,17 @@
+$body$
+$if(publications)$
+  <section class="level3" id="publications">
+    <h3>Publications</h3>
+    <div class="post-list">
+      $for(publications)$
+        <div class="post-wrapper">
+          <div class="post">
+            <div class="post-teaser">
+              $partial("templates/citation-entry.html")$
+            </div>
+          </div>
+        </div>
+      $endfor$
+    </div>
+  </section>
+$endif$

--- a/content/templates/publication-list.html
+++ b/content/templates/publication-list.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="sidebar"></div>
   <div class="content">
-    $for(publications)$
+    $for(publications-by-year)$
       <h2 id="$year$">$year$</h2>
       <div class="post-list">
         $for(publications-for-year)$

--- a/haskell/Site.hs
+++ b/haskell/Site.hs
@@ -4,6 +4,7 @@ import Data.Monoid ((<>))
 
 import Hakyll
 
+import WebSite.Config
 import WebSite.Context
 import WebSite.Compilers
 import qualified WebSite.Work as Work
@@ -25,8 +26,9 @@ main = hakyllWith config $ do
 
     match "templates/*" $ compile templateCompiler
 
-    match "resources/bibliography/apa.csl" $ compile cslCompiler
-    match "resources/bibliography/mfish.bib" $ compile biblioCompiler
+    match (fromList [cslIdentifier, cslNoBibIdentifier]) $ compile cslCompiler
+    match (fromList [bibIdentifier]) $ compile biblioCompiler
+
     match "**/*.img.md" $ compile scholmdCompiler
     match ("images/*" .||.  "google*.html" .||. "**/*.jpg" .||. "**/*.png") $ do
         route idRoute

--- a/haskell/WebSite/Config.hs
+++ b/haskell/WebSite/Config.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | This module contains values related to configuration.
+module WebSite.Config where
+
+import qualified Data.List as List
+
+import Hakyll
+
+cslIdentifier, cslNoBibIdentifier :: Identifier
+cslIdentifier      = "resources/bibliography/apa.csl"
+cslNoBibIdentifier = "resources/bibliography/apa-nobib.csl"
+
+bibIdentifier :: Identifier
+bibIdentifier = "resources/bibliography/mfish.bib"
+
+-- | Make a publication path for a reference ID
+mkPublicationPath :: String -> FilePath
+mkPublicationPath i = "publications/" ++ i ++ ".md"
+
+-- | Extract the reference ID from a publication identifier
+extractRefId :: Identifier -> String
+extractRefId i
+  | Just s1 <- List.stripPrefix "publications/" $ toFilePath i
+  , s2 <- takeWhile (/= '.') s1
+  , not (null s2) = s2
+  | otherwise = error $ "Identifier '" ++ toFilePath i ++ "' is not a publication"
+
+-- | Make a publication pattern for a reference ID.
+mkPublicationPattern :: String -> Pattern
+mkPublicationPattern = fromGlob . mkPublicationPath
+
+allPublicationsPattern :: Pattern
+allPublicationsPattern = mkPublicationPattern "*"
+
+allPublicationsByYearPattern :: Pattern
+allPublicationsByYearPattern = mkPublicationPattern "year/*"
+
+allCitationsPattern :: Pattern
+allCitationsPattern = allPublicationsPattern .&&. hasVersion citationsVersion
+
+allCitationsByYearPattern :: Pattern
+allCitationsByYearPattern = allPublicationsByYearPattern .&&. hasVersion citationsVersion
+
+citationsVersion :: String
+citationsVersion = "citations"
+
+citationsSnapshot :: Snapshot
+citationsSnapshot = "citations"

--- a/haskell/WebSite/Util.hs
+++ b/haskell/WebSite/Util.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | This module contains utility values used in other modules.
+module WebSite.Util where
+
+import qualified Data.List as List
+import qualified Data.Set as Set
+
+import Control.Monad ((>=>))
+import Data.Default (def)
+
+import Hakyll
+
+import Text.Pandoc.Definition (Inline(..), Citation(..), Pandoc)
+import Text.Pandoc.Options (WriterOptions(..))
+import Text.Pandoc.Walk (Walkable(..))
+
+import WebSite.Config
+
+-- | Get a list of citation items after filtering and sorting the bibliography
+getCitationsWith :: Ord a => (Identifier -> Bool) -> (Identifier -> a) -> Compiler [Item String]
+getCitationsWith filterCond sortCond =
+    loadAllSnapshots allCitationsPattern citationsSnapshot
+        >>= return . List.sortOn (sortCond   . itemIdentifier)
+                   . filter      (filterCond . itemIdentifier)
+
+-- | Get the citation items for a list of citation ID strings
+getCitationsById :: Ord a => (Identifier -> a) -> [String] -> Compiler [Item String]
+getCitationsById sortCond ids =
+    getCitationsWith (flip Set.member (Set.fromList ids) . extractRefId) sortCond
+
+-- | Collection citation IDs from something walkable
+collectCitationIds :: Walkable Inline a => a -> [String]
+collectCitationIds = List.nub . query go
+  where
+    go :: Inline -> [String]
+    go (Cite citations _) = map citationId citations
+    go _                  = []
+
+-- | Options for an HTML5 Pandoc writer
+htm5Writer :: WriterOptions
+htm5Writer = defaultHakyllWriterOptions
+    { writerHtml5       = True
+    , writerSectionDivs = True
+    }
+
+-- | Render a Pandoc input string to HTML5 output with a CSL style and a
+-- bibliography.
+renderPandocBiblio
+    :: Item CSL
+    -> Item Biblio
+    -> Item String
+    -> Compiler (Item String)
+renderPandocBiblio csl bib =
+    readPandocBiblio def csl bib >=> return . writePandocWith htm5Writer
+
+-- | Compile something wrapped as an Item
+asItem :: a -> (Item a -> Compiler (Item b)) -> Compiler b
+asItem x f = makeItem x >>= f >>= return . itemBody
+
+-- Sort items by a monadic ordering function
+sortItemsBy :: (Ord b, Monad m) => (Identifier -> m b) -> [Item a] -> m [Item a]
+sortItemsBy f = sortByM $ f . itemIdentifier
+  where
+    sortByM :: (Monad m, Ord k) => (a -> m k) -> [a] -> m [a]
+    sortByM f xs = map fst . List.sortOn snd <$> mapM (\x -> (x,) <$> f x) xs
+
+listFieldR :: Monad m => String -> Context a -> [Item a] -> m (Context b)
+listFieldR name ctx = return . listField name ctx . return


### PR DESCRIPTION
This implements citation templates for the publication list at the end of a page that has citations in it. The implementation is described as option 2 in a [comment](https://github.com/dragonfly-science/website/issues/12#issuecomment-122211973) to #12.

*Changes*

* Add some modules for common configuration and utility functions
* Use a fork of the bibliography submodule with a duplicated apa.csl that has the <bibliography> removed
* Changed content/news/2011-04-13-estimated-sea-lion-bycatch-2008-09.md to demonstrate how the citations would be in the metadata and how the publications section would appear

This uses my own fork of dragonfly-science/bibliography with a duplicated `apa.csl` as `apa-nobib.csl` to remove the bibliography.

An alternative to this would be to read `apa.csl` and create the different version in-memory. This will mean that we have to write our own versions of the functions in [`Hakyll.Web.Pandoc.Biblio `](https://hackage.haskell.org/package/hakyll-4.7.1.0/docs/Hakyll-Web-Pandoc-Biblio.html) (which would not be difficult) because those functions expect to be reading from files.

Yet another alternative would be to copy `apa.csl` at startup and modify the copy before doing any Hakyll stuff.