### PR TITLE
Update citations in people pages for template

### DIFF
--- a/content/people/abraham-edward.md
+++ b/content/people/abraham-edward.md
@@ -7,6 +7,10 @@ tag: edward
 title: Edward Abraham, PhD
 banner: abraham-edward/edward-abraham-letterbox.jpg
 sortorder: 1
+nocite: |
+  @abraham2000isd
+  @abraham_effectiveness_2009
+  @richard_risk_2013
 ---
 
 Edward is the founder and CEO of Dragonfly. He enjoys bringing evidence to the
@@ -26,9 +30,3 @@ the physical and biological environment. Since starting Dragonfly, he has focuss
 > Statistical analysis is at the heart of the decision making process. It 
 > allows managers to balance opportunity and risk, 
 > resulting in principled decisions that make best use of available information.
-
-## Selected publications {.hide-cite-para}
-
-@abraham2000isd
-@abraham_effectiveness_2009
-@richard_risk_2013

--- a/content/people/berkenbusch-katrin.md
+++ b/content/people/berkenbusch-katrin.md
@@ -31,7 +31,3 @@ that will tell them how their local cockle and pipi populations are faring, espe
 those on beaches that are under a lot of pressure from recreational fishing. As 
 science providers, Dragonfly is an important link between the resource managers 
 and the public.
-
-
-##Selected publications
-

--- a/content/people/neubauer-philipp.md
+++ b/content/people/neubauer-philipp.md
@@ -7,6 +7,11 @@ mobile: ''
 tag: philipp
 title: Philipp Neubauer, PhD
 banner: neubauer-philipp/philipp-neubauer-letterbox.jpg
+nocite: |
+  @neubauer2013resilience
+  @neubauer2013inferring
+  @neubauer_assessing_2014
+  @neubauer2014bayesian
 ---
 
 Philipp is a fisheries scientist who uses statistical analysis to inform actions that promote sustainable fisheries. 
@@ -39,9 +44,3 @@ fisheries science offers a way to balance conservation issues with the need to
 feed the world’s population.
 
 Technical skills: Bayesian analysis; JAGS; R
-
-##Selected publications
-@neubauer2013resilience
-@neubauer2013inferring
-@neubauer_assessing_2014
-@neubauer2014bayesian

--- a/content/people/richard-yvan.md
+++ b/content/people/richard-yvan.md
@@ -7,6 +7,11 @@ title: Yvan Richard, PhD
 mobile: ''
 tag: yvan
 banner: richard-yvan/yvan-richard-letterbox.jpg
+nocite: |
+  @boulton2008influence
+  @richard2010cost
+  @richard_risk_2013
+  @richard_demographic_2013
 ---
 Yvan specialises in using the statistical computing software, R, to solve complex problems. 
 <!--more-->
@@ -34,10 +39,3 @@ and I feel I'm doing something very useful. There's a great atmosphere here and
 we have plenty of fun in the team. It's the best job.
 
 Technical skills: R; GGplot; QGis; Grass; LaTeX
-
-## Selected publications
-
-@boulton2008influence
-@richard2010cost
-@richard_risk_2013
-@richard_demographic_2013

--- a/content/people/thompson-finlay.md
+++ b/content/people/thompson-finlay.md
@@ -8,6 +8,9 @@ tag: finlay
 title: Finlay Thompson, PhD
 banner: thompson-finlay/finlay-thompson-letterbox.jpg
 sortorder: 2
+nocite: |
+  @thompson_mammals_95-12
+  @thompson_dolphin_2013
 ---
 
 Finlay is operations manager at Dragonfly. As a mathematician, he brings an insightful rigour
@@ -39,9 +42,3 @@ investment. It's gratifying to see our work being used to inform key commercial 
 government decisions. 
 
 Technical skills: Bayesian modelling; Haskell; PostgreSQL; Django, LaTeX
-
-##Selected publications
-
-@thompson_mammals_95-12
-@thompson_dolphin_2013
-

--- a/content/stylesheets/_biblio.scss
+++ b/content/stylesheets/_biblio.scss
@@ -1,8 +1,3 @@
-
-.hide-cite-para > p {
-    display: none;
-}
-
 #selected-publications > p {
     display: none;
 }


### PR DESCRIPTION
The current citation approach on the people pages clashes with the new `content/templates/append-publications.html`. This PR changes it by:

1. removing the “Selected publications” header and
2. putting the citations in the YAML `nocite` field.

The result is a “Publications” header and section that looks identical to the one used on all collections. It may be that you want different templates for publications sections on different page types. It's easy enough to do.